### PR TITLE
Use RecordError and RecordWarning

### DIFF
--- a/plotjuggler_plugins/ParserProtobuf/error_collectors.cpp
+++ b/plotjuggler_plugins/ParserProtobuf/error_collectors.cpp
@@ -2,38 +2,39 @@
 #include <QMessageBox>
 #include <QDebug>
 
-void FileErrorCollector::AddError(const std::string& filename, int line, int,
-                                  const std::string& message)
+void FileErrorCollector::RecordError(const absl::string_view filename, int line, int,
+                                  const absl::string_view message)
 {
   auto msg = QString("File: [%1] Line: [%2] Message: %3\n\n")
-                 .arg(QString::fromStdString(filename))
-                 .arg(line)
-                 .arg(QString::fromStdString(message));
+               .arg(QString::fromStdString(std::string{filename}))
+               .arg(line)
+               .arg(QString::fromStdString(std::string{message}));
 
   _errors.push_back(msg);
 }
 
-void FileErrorCollector::AddWarning(const std::string& filename, int line, int,
-                                    const std::string& message)
+void FileErrorCollector::RecordWarning(const absl::string_view filename, int line, int,
+                                    const absl::string_view message)
 {
   auto msg = QString("Warning [%1] line %2: %3")
-                 .arg(QString::fromStdString(filename))
-                 .arg(line)
-                 .arg(QString::fromStdString(message));
+               .arg(QString::fromStdString(std::string{filename}))
+               .arg(line)
+               .arg(QString::fromStdString(std::string{message}));
   qDebug() << msg;
 }
 
-void IoErrorCollector::AddError(int line, google::protobuf::io::ColumnNumber,
-                                const std::string& message)
+void IoErrorCollector::RecordError(int line, google::protobuf::io::ColumnNumber,
+                                const absl::string_view message)
 {
-  _errors.push_back(
-      QString("Line: [%1] Message: %2\n").arg(line).arg(QString::fromStdString(message)));
+  _errors.push_back(QString("Line: [%1] Message: %2\n")
+                      .arg(line)
+                    .arg(QString::fromStdString(std::string{message})));
 }
 
-void IoErrorCollector::AddWarning(int line, google::protobuf::io::ColumnNumber column,
-                                  const std::string& message)
+void IoErrorCollector::RecordWarning(int line, google::protobuf::io::ColumnNumber column,
+                                  const absl::string_view message)
 {
-  qDebug() << QString("Line: [%1] Message: %2\n")
-                  .arg(line)
-                  .arg(QString::fromStdString(message));
+    qDebug() << QString("Line: [%1] Message: %2\n")
+                .arg(line)
+                .arg(QString::fromStdString(std::string{message}));
 }

--- a/plotjuggler_plugins/ParserProtobuf/error_collectors.h
+++ b/plotjuggler_plugins/ParserProtobuf/error_collectors.h
@@ -6,14 +6,16 @@
 
 #include <QStringList>
 
-class IoErrorCollector : public google::protobuf::io::ErrorCollector
+#include "absl/strings/string_view.h"
+
+class IoErrorCollector: public google::protobuf::io::ErrorCollector
 {
 public:
-  void AddError(int line, google::protobuf::io::ColumnNumber column,
-                const std::string& message) override;
+  void RecordError(int line, google::protobuf::io::ColumnNumber column,
+                const absl::string_view message) override;
 
-  void AddWarning(int line, google::protobuf::io::ColumnNumber column,
-                  const std::string& message) override;
+  void RecordWarning(int line, google::protobuf::io::ColumnNumber column,
+                  const absl::string_view message) override;
 
   const QStringList& errors()
   {
@@ -24,14 +26,14 @@ private:
   QStringList _errors;
 };
 
-class FileErrorCollector : public google::protobuf::compiler::MultiFileErrorCollector
+class FileErrorCollector: public google::protobuf::compiler::MultiFileErrorCollector
 {
 public:
-  void AddError(const std::string& filename, int line, int,
-                const std::string& message) override;
+  void RecordError(const absl::string_view filename, int line, int,
+                const absl::string_view message) override;
 
-  void AddWarning(const std::string& filename, int line, int,
-                  const std::string& message) override;
+  void RecordWarning(const absl::string_view filename, int line, int,
+                  const absl::string_view message) override;
 
   const QStringList& errors()
   {
@@ -42,4 +44,8 @@ private:
   QStringList _errors;
 };
 
+<<<<<<< HEAD
 #endif  // ERROR_COLLECTORS_H
+=======
+#endif // ERROR_COLLECTORS_H
+>>>>>>> 93616d01 (Use RecordError and RecordWarning)


### PR DESCRIPTION
AddError and AddWarning have been deprecated: https://github.com/protocolbuffers/protobuf/commit/543fbcdbd9496de9d93a6eb4645640cb47a5514b.

Instead RecordError and RecordWarning shall be used.